### PR TITLE
Associate comments with a nickname and email

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/Comment.java
@@ -6,6 +6,8 @@ package com.google.sps.servlets;
  */
 public class Comment {
     private long id;
+    private String email;
+    private String nickname;
     private String text;
     private long timestamp;
 
@@ -13,11 +15,15 @@ public class Comment {
      * Comment constructor.
      * 
      * @param id The unique identifier of this comment.
+     * @param email Email associated with the comment.
+     * @param nickname Nickname associated with the comment.
      * @param text The text content of this comment.
      * @param timestamp The time, in milliseconds, that this comment was submitted.
      */
-    public Comment(long id, String text, long timestamp) {
+    public Comment(long id, String email, String nickname, String text, long timestamp) {
         this.id = id;
+        this.email = email;
+        this.nickname = nickname;
         this.text = text;
         this.timestamp = timestamp;
     }
@@ -31,6 +37,24 @@ public class Comment {
         return id;
     }
 
+    /**
+     * Returns the comment's email.
+     * 
+     * @return The comment's email.
+     */
+    public String getEmail() {
+        return email;
+    }
+
+    /**
+     * Returns the comment's nickname.
+     * 
+     * @return The comment's nickname.
+     */
+    public String getNickname() {
+        return nickname;
+    }
+    
     /**
      * Returns the comment's text content.
      * 
@@ -55,6 +79,10 @@ public class Comment {
      * @return A string containing the comment's contents.
      */
     public String toString() {
-        return id + ": " + text + " " + timestamp;
+        return "ID: " + id + "," +
+               "Email: " + email + "," +
+               "Nickname: " + nickname + "," +
+               "Text: " + text + "," +
+               "Timestamp: " + timestamp;
     }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/Comment.java
@@ -6,26 +6,23 @@ package com.google.sps.servlets;
  */
 public class Comment {
     private long id;
-    private String email;
     private String nickname;
     private String text;
-    private long timestamp;
+    private boolean isOwner;
 
     /**
      * Comment constructor.
      * 
      * @param id The unique identifier of this comment.
-     * @param email Email associated with the comment.
      * @param nickname Nickname associated with the comment.
      * @param text The text content of this comment.
-     * @param timestamp The time, in milliseconds, that this comment was submitted.
+     * @param isOwner True if the logged in user wrote this comment.
      */
-    public Comment(long id, String email, String nickname, String text, long timestamp) {
+    public Comment(long id, String nickname, String text, boolean isOwner) {
         this.id = id;
-        this.email = email;
         this.nickname = nickname;
         this.text = text;
-        this.timestamp = timestamp;
+        this.isOwner = isOwner;
     }
 
     /**
@@ -35,15 +32,6 @@ public class Comment {
      */
     public long getId() {
         return id;
-    }
-
-    /**
-     * Returns the comment's email.
-     * 
-     * @return The comment's email.
-     */
-    public String getEmail() {
-        return email;
     }
 
     /**
@@ -65,12 +53,12 @@ public class Comment {
     }
 
     /**
-     * Returns the comment's timestamp.
+     * Returns if the logged in user is the owner of this comment.
      * 
-     * @return The comment's timestamp.
+     * @return True if the logged in user owns this comment.
      */
-    public long getTimestamp() {
-        return timestamp;
+    public boolean getIsOwner() {
+        return isOwner;
     }
 
     /**
@@ -80,9 +68,8 @@ public class Comment {
      */
     public String toString() {
         return "ID: " + id + "," +
-               "Email: " + email + "," +
                "Nickname: " + nickname + "," +
                "Text: " + text + "," +
-               "Timestamp: " + timestamp;
+               "IsOwner: " + isOwner;
     }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/GetCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/GetCommentsServlet.java
@@ -53,7 +53,7 @@ public class GetCommentsServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     UserService userService = UserServiceFactory.getUserService();
 
-    // Obtain and prepare comments from Datastore
+    // Obtain and prepare comments from Datastore.
     Query commentsQuery = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     List<Entity> commentsPrepared =

--- a/portfolio/src/main/java/com/google/sps/servlets/GetCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/GetCommentsServlet.java
@@ -71,12 +71,8 @@ public class GetCommentsServlet extends HttpServlet {
       String text = (String) entity.getProperty("text");
 
       // Determine if the logged in user is the owner of this comment;
-      boolean isOwner;
-      if (userService.isUserLoggedIn()) {
-        isOwner = email.equals(userService.getCurrentUser().getEmail());
-      } else {
-        isOwner = false;
-      }
+      boolean isOwner = userService.isUserLoggedIn() && 
+                        email.equals(userService.getCurrentUser().getEmail());
 
       Comment comment = new Comment(id, nickname, text, isOwner);
       comments.add(comment);

--- a/portfolio/src/main/java/com/google/sps/servlets/GetCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/GetCommentsServlet.java
@@ -61,10 +61,12 @@ public class GetCommentsServlet extends HttpServlet {
       entity = commentsIterator.next();
 
       long id = entity.getKey().getId();
+      String email = (String) entity.getProperty("email");
+      String nickname = (String) entity.getProperty("nickname");
       String text = (String) entity.getProperty("text");
       long timestamp = (long) entity.getProperty("timestamp");
 
-      Comment comment = new Comment(id, text, timestamp);
+      Comment comment = new Comment(id, email, nickname, text, timestamp);
       comments.add(comment);
 
       countComments++;

--- a/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
@@ -34,12 +34,13 @@ public class NewCommentServlet extends HttpServlet {
   /**
    * {@inheritDoc}
    *
-   * Stores the given comment in the datastore.
+   * Stores the given comment in the datastore with various parameters identifying the owner of the
+   * comment.
    */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     UserService userService = UserServiceFactory.getUserService();
-    
+
     String email = userService.getCurrentUser().getEmail();
     String nickname = request.getParameter("nickname");
     String text = request.getParameter("comment-text");
@@ -50,12 +51,10 @@ public class NewCommentServlet extends HttpServlet {
       return;
     }
 
-    // Set nickname to "Anonymous" if none specified
     if (nickname == null || nickname.isEmpty()) {
       nickname = "Anonymous";
     }
 
-    // Create new entity for the comment and store in Datastore
     Entity commentEntity = new Entity("Comment");
     commentEntity.setProperty("email", email);
     commentEntity.setProperty("nickname", nickname);

--- a/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
@@ -59,6 +59,7 @@ public class NewCommentServlet extends HttpServlet {
     // Create new entity for the comment and store in Datastore
     Entity commentEntity = new Entity("Comment");
     commentEntity.setProperty("email", email);
+    commentEntity.setProperty("nickname", nickname);
     commentEntity.setProperty("text", text);
     commentEntity.setProperty("timestamp", timestamp);
 

--- a/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NewCommentServlet.java
@@ -17,6 +17,8 @@ package com.google.sps.servlets;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -36,6 +38,10 @@ public class NewCommentServlet extends HttpServlet {
    */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    UserService userService = UserServiceFactory.getUserService();
+    
+    String email = userService.getCurrentUser().getEmail();
+    String nickname = request.getParameter("nickname");
     String text = request.getParameter("comment-text");
     long timestamp = System.currentTimeMillis();
 
@@ -45,8 +51,14 @@ public class NewCommentServlet extends HttpServlet {
       return;
     }
 
+    // Set nickname to "Anonymous" if none specified
+    if (nickname == null || nickname.isEmpty()) {
+      nickname = "Anonymous";
+    }
+
     // Create new entity for the comment and store in Datastore
     Entity commentEntity = new Entity("Comment");
+    commentEntity.setProperty("email", email);
     commentEntity.setProperty("text", text);
     commentEntity.setProperty("timestamp", timestamp);
 

--- a/portfolio/src/main/webapp/comments.html
+++ b/portfolio/src/main/webapp/comments.html
@@ -29,7 +29,11 @@
 
     <!-- Form to submit comments -->
     <form id="submit-comment" action="/new-comment" method="POST">
-      <p>Enter your own comment here:</p>
+      <p>
+        Enter your own comment and nickname here (if no nickname specified, 
+        the comment will be listed as Anonymous):
+      </p>
+      <input type="text" name="nickname" placeholder="Nickname"/>
       <textarea name="comment-text" placeholder="Your comment here..."></textarea>
       <input type="submit"/>
     </form>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -94,7 +94,7 @@ function createCommentListItem(comment) {
 
   // Create the comment text to put into the list item
   const listText = document.createElement("span");
-  listText.innerText = comment.text;
+  listText.innerText = comment.nickname + ": " + comment.text;
 
   // Create the delete button to put into the list item
   const deleteButton = document.createElement("button");

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -95,6 +95,7 @@ function createCommentListItem(comment) {
   // Create the comment text to put into the list item
   const listText = document.createElement("span");
   listText.innerText = comment.nickname + ": " + comment.text;
+  listItem.appendChild(listText);
 
   // Create the delete button to put into the list item if the logged in user
   // owns the comment
@@ -105,10 +106,9 @@ function createCommentListItem(comment) {
       deleteComment(comment);
       listItem.remove();
     });
+    listItem.appendChild(deleteButton);
   }
 
-  listItem.appendChild(listText);
-  listItem.appendChild(deleteButton);
   return listItem;
 }
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -35,7 +35,7 @@ function authenticateUser() {
     .then(response => response.json())
     .then(authenticationResults => {
       authenticationContainer.innerHTML = authenticationResults.message;
-      
+
       if (!authenticationResults.isLoggedIn) {
         submitCommentForm.classList.add("hidden");
       }
@@ -62,7 +62,6 @@ function getComments() {
         commentsList.appendChild(createCommentListItem(comment));
       })
     }).catch(error => {
-      // Display generic error message in case of server error
       document.getElementById("comments-list").innerText = error;
   });
 }
@@ -88,17 +87,16 @@ function handleFetchErrors(response) {
  * @returns {HTMLLIElement} The list item to append to the comments list.
  */
 function createCommentListItem(comment) {
-  // Create the list item
+  // Create the list item.
   const listItem = document.createElement("li");
   listItem.className = "comment";
 
-  // Create the comment text to put into the list item
+  // Create the comment text to put into the list item.
   const listText = document.createElement("span");
   listText.innerText = comment.nickname + ": " + comment.text;
   listItem.appendChild(listText);
 
-  // Create the delete button to put into the list item if the logged in user
-  // owns the comment
+  // Only show delete button to owner of the comment.
   if (comment.isOwner) {
     const deleteButton = document.createElement("button");
     deleteButton.innerText = "Delete";

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -96,13 +96,16 @@ function createCommentListItem(comment) {
   const listText = document.createElement("span");
   listText.innerText = comment.nickname + ": " + comment.text;
 
-  // Create the delete button to put into the list item
-  const deleteButton = document.createElement("button");
-  deleteButton.innerText = "Delete";
-  deleteButton.addEventListener("click", () => {
-    deleteComment(comment);
-    listItem.remove();
-  });
+  // Create the delete button to put into the list item if the logged in user
+  // owns the comment
+  if (comment.isOwner) {
+    const deleteButton = document.createElement("button");
+    deleteButton.innerText = "Delete";
+    deleteButton.addEventListener("click", () => {
+      deleteComment(comment);
+      listItem.remove();
+    });
+  }
 
   listItem.appendChild(listText);
   listItem.appendChild(deleteButton);


### PR DESCRIPTION
This branch is built off of the branch "users-api". Comments can now have a nickname associated with them. Comments can now also be deleted only if the logged in user's email matches the email associated with the comment.

Image (kind of ugly layout-wise but I'll leave that to styling later):
![Screenshot from 2020-06-09 20-47-09](https://user-images.githubusercontent.com/32619061/84215260-b44bc380-aa93-11ea-9a66-f5e43c2062e6.png)

TESTED=Nickname now appears alongside the comment, and the delete button only appears if the logged in user originally wrote the comment.