### PR TITLE
Meeting query with optional attendees

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -54,7 +54,7 @@ public final class FindMeetingQuery {
         removeTimesBelowDuration(availableTimesWithOptional, request.getDuration());
 
     // We must also check that mandatory attendees is not empty. If there are only optional
-    // attendees, we do not with to accidentally return the entire day since it is the base case.
+    // attendees, we do not wish to accidentally return the entire day since it is the base case.
     return availableTimesWithOptional.isEmpty() && !request.getAttendees().isEmpty()
         ? availableTimesWithoutOptional
         : availableTimesWithOptional;

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -39,8 +39,10 @@ public final class FindMeetingQuery {
     // returned when no attendees are given.
     ArrayList<TimeRange> base = new ArrayList<TimeRange>();
     base.add(TimeRange.WHOLE_DAY);
-    ArrayList<TimeRange> availableTimesWithoutOptional = allTimeRangesIntersection(attendeeAvailabilities, base);
-    ArrayList<TimeRange> availableTimesWithOptional = allTimeRangesIntersection(optionalAttendeeAvailabilities, availableTimesWithoutOptional);
+    ArrayList<TimeRange> availableTimesWithoutOptional =
+        allTimeRangesIntersection(attendeeAvailabilities, base);
+    ArrayList<TimeRange> availableTimesWithOptional =
+        allTimeRangesIntersection(optionalAttendeeAvailabilities, availableTimesWithoutOptional);
 
     availableTimesWithoutOptional =
         removeTimesBelowDuration(availableTimesWithoutOptional, request.getDuration());

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -52,11 +52,13 @@ public final class FindMeetingQuery {
     }
 
     availableTimesWithoutOptional =
-      removeTimesBelowDuration(availableTimesWithoutOptional, request.getDuration());
+        removeTimesBelowDuration(availableTimesWithoutOptional, request.getDuration());
     availableTimesWithOptional =
-      removeTimesBelowDuration(availableTimesWithOptional, request.getDuration());
+        removeTimesBelowDuration(availableTimesWithOptional, request.getDuration());
 
-    return availableTimesWithOptional.isEmpty() && !request.getAttendees().isEmpty() ? availableTimesWithoutOptional : availableTimesWithOptional;
+    return availableTimesWithOptional.isEmpty() && !request.getAttendees().isEmpty()
+        ? availableTimesWithoutOptional
+        : availableTimesWithOptional;
   }
 
   /**

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -50,7 +50,7 @@ public final class FindMeetingQuery {
         removeTimesBelowDuration(availableTimesWithOptional, request.getDuration());
 
     // We must also check that mandatory attendees is not empty. If there are only optional
-    // attendees, we do not with to accidentally return the entire day since it is  base case.
+    // attendees, we do not with to accidentally return the entire day since it is the base case.
     return availableTimesWithOptional.isEmpty() && !request.getAttendees().isEmpty()
         ? availableTimesWithoutOptional
         : availableTimesWithOptional;

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -91,8 +91,8 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true));
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
+            TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -117,9 +117,9 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
-            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, /*inclusiveEnd=*/false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, /*inclusiveEnd=*/false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -147,9 +147,9 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
-            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, /*inclusiveEnd=*/false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, /*inclusiveEnd=*/false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -178,8 +178,8 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, /*inclusiveEnd=*/false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -204,8 +204,8 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
+            TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -231,8 +231,8 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
+            TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -256,8 +256,8 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -282,8 +282,8 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0900AM, false),
-            TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, true));
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0900AM, /*inclusiveEnd=*/false),
+            TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -298,9 +298,9 @@ public final class FindMeetingQueryTest {
     // Options :       |-----|
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true),
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
@@ -324,11 +324,11 @@ public final class FindMeetingQueryTest {
     // Options :       |-----|
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true),
             Arrays.asList(PERSON_A)),
-        new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0845AM, false),
+        new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0845AM, /*inclusiveEnd=*/false),
             Arrays.asList(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
@@ -376,9 +376,9 @@ public final class FindMeetingQueryTest {
     // Options :
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true),
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
@@ -408,9 +408,9 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
-            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, /*inclusiveEnd=*/false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, /*inclusiveEnd=*/false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -423,9 +423,9 @@ public final class FindMeetingQueryTest {
     // Day     : |-----------------------------|
     // Options :
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TIME_0100AM, TIME_1000AM, false),
+        new Event("Event 1", TimeRange.fromStartEnd(TIME_0100AM, TIME_1000AM, /*inclusiveEnd=*/false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, true),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true),
             Arrays.asList(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_2_HOUR);

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -90,9 +90,9 @@ public final class FindMeetingQueryTest {
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
-            TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
+    Collection<TimeRange> expected = Arrays.asList(
+        TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
+        TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -116,10 +116,10 @@ public final class FindMeetingQueryTest {
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, /*inclusiveEnd=*/false),
-            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, /*inclusiveEnd=*/false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
+    Collection<TimeRange> expected = Arrays.asList(
+        TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, /*inclusiveEnd=*/false),
+        TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, /*inclusiveEnd=*/false),
+        TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -146,10 +146,10 @@ public final class FindMeetingQueryTest {
     request.addOptionalAttendee(PERSON_C);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, /*inclusiveEnd=*/false),
-            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, /*inclusiveEnd=*/false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
+    Collection<TimeRange> expected = Arrays.asList(
+        TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, /*inclusiveEnd=*/false),
+        TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, /*inclusiveEnd=*/false),
+        TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -177,9 +177,9 @@ public final class FindMeetingQueryTest {
     request.addOptionalAttendee(PERSON_C);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, /*inclusiveEnd=*/false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
+    Collection<TimeRange> expected = Arrays.asList(
+        TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, /*inclusiveEnd=*/false),
+        TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -203,9 +203,9 @@ public final class FindMeetingQueryTest {
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
-            TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
+    Collection<TimeRange> expected = Arrays.asList(
+        TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
+        TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -230,9 +230,9 @@ public final class FindMeetingQueryTest {
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
-            TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
+    Collection<TimeRange> expected = Arrays.asList(
+        TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
+        TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -255,9 +255,9 @@ public final class FindMeetingQueryTest {
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
+    Collection<TimeRange> expected = Arrays.asList(
+        TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
+        TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -281,9 +281,9 @@ public final class FindMeetingQueryTest {
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0900AM, /*inclusiveEnd=*/false),
-            TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
+    Collection<TimeRange> expected = Arrays.asList(
+        TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0900AM, /*inclusiveEnd=*/false),
+        TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -298,9 +298,11 @@ public final class FindMeetingQueryTest {
     // Options :       |-----|
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
+        new Event("Event 1",
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true),
+        new Event("Event 2",
+            TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true),
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
@@ -324,11 +326,14 @@ public final class FindMeetingQueryTest {
     // Options :       |-----|
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
+        new Event("Event 1",
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true),
+        new Event("Event 2",
+            TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true),
             Arrays.asList(PERSON_A)),
-        new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0845AM, /*inclusiveEnd=*/false),
+        new Event("Event 3",
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0845AM, /*inclusiveEnd=*/false),
             Arrays.asList(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
@@ -376,9 +381,11 @@ public final class FindMeetingQueryTest {
     // Options :
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
+        new Event("Event 1",
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, /*inclusiveEnd=*/false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true),
+        new Event("Event 2",
+            TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true),
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
@@ -407,10 +414,10 @@ public final class FindMeetingQueryTest {
     request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, /*inclusiveEnd=*/false),
-            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, /*inclusiveEnd=*/false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
+    Collection<TimeRange> expected = Arrays.asList(
+        TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, /*inclusiveEnd=*/false),
+        TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, /*inclusiveEnd=*/false),
+        TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true));
 
     Assert.assertEquals(expected, actual);
   }
@@ -422,11 +429,13 @@ public final class FindMeetingQueryTest {
     // Events  :    |=====A=====| |======B=====|
     // Day     : |-----------------------------|
     // Options :
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TIME_0100AM, TIME_1000AM, /*inclusiveEnd=*/false),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true),
-            Arrays.asList(PERSON_B)));
+    Collection<Event> events =
+        Arrays.asList(new Event("Event 1",
+                          TimeRange.fromStartEnd(TIME_0100AM, TIME_1000AM, /*inclusiveEnd=*/false),
+                          Arrays.asList(PERSON_A)),
+            new Event("Event 2",
+                TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, /*inclusiveEnd=*/true),
+                Arrays.asList(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_2_HOUR);
     request.addOptionalAttendee(PERSON_A);
@@ -438,4 +447,3 @@ public final class FindMeetingQueryTest {
     Assert.assertEquals(expected, actual);
   }
 }
-

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -34,10 +34,13 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
+  private static final int TIME_0100AM = TimeRange.getTimeInMinutes(1, 0);
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
   private static final int TIME_0830AM = TimeRange.getTimeInMinutes(8, 30);
+  private static final int TIME_0845AM = TimeRange.getTimeInMinutes(8, 45);
   private static final int TIME_0900AM = TimeRange.getTimeInMinutes(9, 0);
   private static final int TIME_0930AM = TimeRange.getTimeInMinutes(9, 30);
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
@@ -116,6 +119,66 @@ public final class FindMeetingQueryTest {
     Collection<TimeRange> expected =
         Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void everyAttendeeIsConsideredWithOptionalAllDay() {
+    // Same as everyAttendeeIsConsidered() but with an extra optional attendee who has an all-day
+    // event. Since they are never available, this should return the same three time slots.
+    //
+    // Events  :       |--A--|     |--B--|
+    //           |==============C==============|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.WHOLE_DAY, Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void everyAttendeeIsConsideredWithOptional() {
+    // Same as everyAttendeeIsConsidered() but with an extra optional attendee who has a single
+    // event in the middle of the day. Only the early and late parts of the day should be returned.
+    //
+    // Events  :       |--A--|     |--B--|
+    //                       |==C==|
+    // Day     : |-----------------------------|
+    // Options : |--1--|                 |--2--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
@@ -224,6 +287,35 @@ public final class FindMeetingQueryTest {
   }
 
   @Test
+  public void justEnoughRoomWithOptional() {
+    // Same as justEnoughRoom() but with an optional attendee with an event between 8:30 and 8:45.
+    // This optional attendee should be ignored since there would no longer be any options available
+    // if they were considered.
+    //
+    // Events  : |--A--|     |----A----|
+    //                 |=B=|
+    // Day     : |---------------------|
+    // Options :       |-----|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0845AM, false),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
   public void ignoresPeopleNotAttending() {
     // Add an event, but make the only attendee someone different from the person looking to book
     // a meeting. This event should not affect the booking.
@@ -264,6 +356,55 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void onlyOptionalAttendees() {
+    // No mandatory attendees, only two optional attendees with several gaps in their schedules.
+    //
+    // Events  :       |==A==|     |==B==|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void onlyOptionalAttendeesWithNoGaps() {
+    // No mandatory attendees, only two optional attendees with no gaps in their schedules.
+    //
+    // Events  :    |=====A=====| |======B=====|
+    // Day     : |-----------------------------|
+    // Options :
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TIME_0100AM, TIME_1000AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_1100AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_2_HOUR);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected = Arrays.asList();


### PR DESCRIPTION
Adds testing and implementation for making a meeting query with optional attendees specified.

This implementation allows for optional attendees to be considered by considering availabilities for mandatory and optional attendees separately. It then determines if any times exist for both mandatory and optional attendees. If so, it immediately returns the solution. If not, it returns whatever the solution would be for just mandatory attendees (or no times, if the only attendees specified are all optional). This implementation maintains the time complexity of implementation with just mandatory attendees.

TESTING=ensured all previous and new tests in FindMeetingQueryTest.java passed.